### PR TITLE
Polish elm-glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `miniBill/elm-glob` [![Build Status](https://github.com/miniBill/elm-glob/workflows/CI/badge.svg)](https://github.com/miniBill/elm-glob/actions?query=branch%3Amain)
 
-Matches file paths against a [glob](https://en.wikipedia.org/wiki/Glob_%28programming%29).
+Matches file paths against a [glob](https://man7.org/linux/man-pages/man7/glob.7.html).
 
 ```elm
 import Glob exposing (Glob)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `miniBill/elm-glob` [![Build Status](https://github.com/miniBill/elm-glob/workflows/CI/badge.svg)](https://github.com/miniBill/elm-glob/actions?query=branch%3Amain)
 
-Matches inputs against a [glob](https://en.wikipedia.org/wiki/Glob_%28programming%29).
+Matches file paths against a [glob](https://en.wikipedia.org/wiki/Glob_%28programming%29).
 
 ```elm
 import Glob exposing (Glob)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 Matches inputs against a [glob](https://en.wikipedia.org/wiki/Glob_%28programming%29).
 
-Usage:
-
 ```elm
-import Glob
+import Glob exposing (Glob)
 
-Glob.match "src/*.css" "src/style.css" --> Ok True
-Glob.match "src/file.?sv" "src/file.sv" --> Ok False
+glob : Glob
+glob =
+    Glob.fromString "src/*.css*"
+        |> Result.withDefault Glob.never
+
+Glob.match glob "src/style.css"
+--> True
+
+Glob.match glob "src/file.sv"
+--> False
 ```

--- a/elm.json
+++ b/elm.json
@@ -15,7 +15,6 @@
     },
     "test-dependencies": {
         "elm/json": "1.1.3 <= v < 2.0.0",
-        "elm-explorations/test": "2.2.0 <= v < 3.0.0",
-        "elm-community/list-extra": "8.7.0 <= v < 9.0.0"
+        "elm-explorations/test": "2.2.0 <= v < 3.0.0"
     }
 }

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -118,9 +118,9 @@ componentParser =
             |= Parser.getSource
             |> Parser.andThen
                 (\( fragments, positionAndSource ) ->
-                    Parser.succeed Fragments
-                        |= fragmentsToRegex positionAndSource fragments
+                    fragmentsToRegex positionAndSource fragments
                 )
+            |> Parser.map Fragments
         ]
 
 

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -138,9 +138,10 @@ fragmentsToRegex original fragments =
     let
         regexString : String
         regexString =
-            fragments
-                |> List.map fragmentToRegexString
-                |> String.concat
+            List.foldl
+                (\fragment acc -> acc ++ fragmentToRegexString fragment)
+                ""
+                fragments
     in
     case Regex.fromStringWith { caseInsensitive = False, multiline = True } ("^" ++ regexString ++ "$") of
         Nothing ->

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -1,19 +1,14 @@
 module Glob exposing
-    ( match
-    , Glob, fromString, matchGlob
+    ( Glob, fromString
+    , match
     )
 
-{-|
+{-| A library for working with [glob].
 
+[glob]: https://en.wikipedia.org/wiki/Glob_%28programming%29
 
-# Simple usage
-
+@docs Glob, fromString
 @docs match
-
-
-# Efficient usage
-
-@docs Glob, fromString, matchGlob
 
 -}
 
@@ -22,7 +17,7 @@ import Regex exposing (Regex)
 import Set exposing (Set)
 
 
-{-| A type representing a correctly parsed Glob expression.
+{-| A correctly parsed Glob expression.
 -}
 type Glob
     = Glob (List Component)
@@ -41,21 +36,10 @@ type Fragment
     | Asterisk
 
 
-{-| Match a given glob against an input.
-
-If you want to match the same glob against multiple inputs you should use `parse` and `matchGlob` instead.
-
+{-| Match an input against a glob.
 -}
-match : String -> String -> Result (List Parser.DeadEnd) Bool
-match glob input =
-    fromString glob
-        |> Result.map (\parsed -> matchGlob parsed input)
-
-
-{-| Match a given glob against an input.
--}
-matchGlob : Glob -> String -> Bool
-matchGlob (Glob parsed) input =
+match : Glob -> String -> Bool
+match (Glob parsed) input =
     matchComponents parsed (String.split "/" input)
 
 

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -118,7 +118,7 @@ componentParser =
             |= Parser.getSource
             |> Parser.andThen
                 (\( fragments, original ) ->
-                    Parser.succeed (\regex -> Fragments regex)
+                    Parser.succeed Fragments
                         |= fragmentsToRegex original fragments
                 )
         ]

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -128,10 +128,10 @@ fragmentsToRegex before fragments after source =
         regexString =
             List.foldl
                 (\fragment acc -> acc ++ fragmentToRegexString fragment)
-                ""
+                "^"
                 fragments
     in
-    case Regex.fromStringWith { caseInsensitive = False, multiline = True } ("^" ++ regexString ++ "$") of
+    case Regex.fromStringWith { caseInsensitive = False, multiline = True } (regexString ++ "$") of
         Nothing ->
             Parser.problem <|
                 "Could not parse \""

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -1,5 +1,5 @@
 module Glob exposing
-    ( Glob, fromString
+    ( Glob, fromString, never
     , match
     )
 
@@ -7,7 +7,7 @@ module Glob exposing
 
 [glob]: https://en.wikipedia.org/wiki/Glob_%28programming%29
 
-@docs Glob, fromString
+@docs Glob, fromString, never
 @docs match
 
 -}
@@ -17,7 +17,7 @@ import Regex exposing (Regex)
 import Set exposing (Set)
 
 
-{-| A correctly parsed Glob expression.
+{-| A Glob expression.
 -}
 type Glob
     = Glob (List Component)
@@ -70,7 +70,14 @@ matchComponents components segments =
                 False
 
 
-{-| Parse a string into a `Glob`.
+{-| A `glob` that never matches.
+-}
+never : Glob
+never =
+    Glob []
+
+
+{-| Parse a string into a `glob`.
 -}
 fromString : String -> Result (List Parser.DeadEnd) Glob
 fromString input =

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -14,7 +14,7 @@ module Glob exposing
 
 import Parser exposing ((|.), (|=), Parser)
 import Regex exposing (Regex)
-import Set exposing (Set)
+import Set
 
 
 {-| A Glob expression.
@@ -241,19 +241,17 @@ nonemptyChomper f =
         )
 
 
-specialChars : Set Char
-specialChars =
-    [ '*'
-    , '{'
-    , '}'
-    , '['
-    , ']'
-    , '?'
-    , '/'
-    ]
-        |> Set.fromList
-
-
 notSpecial : Char -> Bool
 notSpecial c =
-    not (Set.member c specialChars)
+    not (isSpecialChar c)
+
+
+isSpecialChar : Char -> Bool
+isSpecialChar c =
+    (c == '/')
+        || (c == '*')
+        || (c == '{')
+        || (c == '}')
+        || (c == '[')
+        || (c == ']')
+        || (c == '?')

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -30,7 +30,7 @@ type Component
 
 type Fragment
     = Literal String
-    | Alternatives (Set String)
+    | Alternatives (List String)
     | Class { negative : Bool, inner : String }
     | QuestionMark
     | Asterisk
@@ -153,7 +153,7 @@ fragmentToRegexString fragment =
             regexEscape literal
 
         Alternatives alternatives ->
-            "(" ++ String.join "|" (List.map regexEscape <| Set.toList alternatives) ++ ")"
+            "(" ++ String.join "|" (List.map regexEscape alternatives) ++ ")"
 
         Class { negative, inner } ->
             let
@@ -209,7 +209,7 @@ fragmentParser =
             |. Parser.symbol "?"
         , Parser.succeed Asterisk
             |. Parser.symbol "*"
-        , Parser.succeed (Alternatives << Set.fromList)
+        , Parser.succeed (Alternatives << Set.toList << Set.fromList)
             |= Parser.sequence
                 { start = "{"
                 , end = "}"

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -104,7 +104,7 @@ componentParser =
     Parser.oneOf
         [ Parser.succeed TwoAsterisks
             |. Parser.symbol "**"
-        , Parser.succeed (\before fragments after source -> ( fragments, ( before, after, source ) ))
+        , Parser.succeed fragmentsToRegex
             |= Parser.getOffset
             |= Parser.sequence
                 { start = ""
@@ -116,16 +116,13 @@ componentParser =
                 }
             |= Parser.getOffset
             |= Parser.getSource
-            |> Parser.andThen
-                (\( fragments, positionAndSource ) ->
-                    fragmentsToRegex positionAndSource fragments
-                )
+            |> Parser.andThen identity
             |> Parser.map Fragments
         ]
 
 
-fragmentsToRegex : ( Int, Int, String ) -> List Fragment -> Parser Regex
-fragmentsToRegex ( before, after, source ) fragments =
+fragmentsToRegex : Int -> List Fragment -> Int -> String -> Parser Regex
+fragmentsToRegex before fragments after source =
     let
         regexString : String
         regexString =

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -104,7 +104,7 @@ componentParser =
     Parser.oneOf
         [ Parser.succeed TwoAsterisks
             |. Parser.symbol "**"
-        , Parser.succeed (\before parsed after source -> ( parsed, String.slice before after source ))
+        , Parser.succeed (\before fragments after source -> ( fragments, ( before, after, source ) ))
             |= Parser.getOffset
             |= Parser.sequence
                 { start = ""
@@ -117,15 +117,15 @@ componentParser =
             |= Parser.getOffset
             |= Parser.getSource
             |> Parser.andThen
-                (\( fragments, original ) ->
+                (\( fragments, positionAndSource ) ->
                     Parser.succeed Fragments
-                        |= fragmentsToRegex original fragments
+                        |= fragmentsToRegex positionAndSource fragments
                 )
         ]
 
 
-fragmentsToRegex : String -> List Fragment -> Parser Regex
-fragmentsToRegex original fragments =
+fragmentsToRegex : ( Int, Int, String ) -> List Fragment -> Parser Regex
+fragmentsToRegex ( before, after, source ) fragments =
     let
         regexString : String
         regexString =
@@ -140,7 +140,7 @@ fragmentsToRegex original fragments =
                 "Could not parse \""
                     ++ regexString
                     ++ "\" as a regex, obtained from "
-                    ++ original
+                    ++ String.slice before after source
 
         Just regex ->
             Parser.succeed regex

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -223,8 +223,7 @@ fragmentParser =
                 , Parser.succeed False
                 ]
             |= Parser.getChompedString
-                (Parser.succeed ()
-                    |. Parser.oneOf [ Parser.symbol "]", Parser.succeed () ]
+                (Parser.oneOf [ Parser.symbol "]", Parser.succeed () ]
                     |. Parser.chompWhile (\c -> c /= ']')
                 )
             |. Parser.symbol "]"

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -25,7 +25,7 @@ type Glob
 
 type Component
     = TwoAsterisks
-    | Fragments ( List Fragment, Regex )
+    | Fragments Regex
 
 
 type Fragment
@@ -62,7 +62,7 @@ matchComponents components segments =
             else
                 matchComponents ctail segments
 
-        ( (Fragments ( _, chead )) :: ctail, shead :: stail ) ->
+        ( (Fragments chead) :: ctail, shead :: stail ) ->
             if Regex.contains chead shead then
                 matchComponents ctail stail
 
@@ -118,7 +118,7 @@ componentParser =
             |= Parser.getSource
             |> Parser.andThen
                 (\( fragments, original ) ->
-                    Parser.succeed (\regex -> Fragments ( fragments, regex ))
+                    Parser.succeed (\regex -> Fragments regex)
                         |= fragmentsToRegex original fragments
                 )
         ]

--- a/src/Glob.elm
+++ b/src/Glob.elm
@@ -36,7 +36,7 @@ type Fragment
     | Asterisk
 
 
-{-| Match an input against a glob.
+{-| Match a file path against a glob.
 -}
 match : Glob -> String -> Bool
 match (Glob parsed) input =

--- a/tests/Examples.elm
+++ b/tests/Examples.elm
@@ -41,7 +41,7 @@ parseTests : Test
 parseTests =
     expectations
         |> Utils.parseAll
-        |> describe "Glob.parse"
+        |> describe "Glob.fromString"
 
 
 matchTests : Test

--- a/tests/Examples.elm
+++ b/tests/Examples.elm
@@ -1,6 +1,9 @@
-module Examples exposing (matchTests, parseTests)
+module Examples exposing (matchTests, neverTests, parseTests)
 
-import Test exposing (Test, describe)
+import Expect
+import Fuzz
+import Glob
+import Test exposing (Test, describe, fuzz)
 import Utils
 
 
@@ -49,3 +52,11 @@ matchTests =
     expectations
         |> Utils.checkAll
         |> describe "Glob.match"
+
+
+neverTests : Test
+neverTests =
+    fuzz Fuzz.string "Glob.match Glob.never should return False for any input" <|
+        \str ->
+            Glob.match Glob.never str
+                |> Expect.equal False

--- a/tests/Utils.elm
+++ b/tests/Utils.elm
@@ -64,7 +64,13 @@ checkAll expectations =
                             Ok validGlob ->
                                 Glob.match validGlob input
                                     |> Expect.equal expected
-                                    |> Expect.onFail "Should not have matched"
+                                    |> Expect.onFail
+                                        (if expected then
+                                            "Should have matched"
+
+                                         else
+                                            "Should not have matched"
+                                        )
                     )
             )
 

--- a/tests/Utils.elm
+++ b/tests/Utils.elm
@@ -49,15 +49,22 @@ checkAll expectations =
             (\{ glob, input, expected } ->
                 test ("Glob: " ++ escape glob ++ " Input: " ++ escape input)
                     (\() ->
-                        -- match to be implemented yourself :D
-                        if Glob.match glob input == Ok expected then
-                            Expect.pass
+                        case Glob.fromString glob of
+                            Err [ single ] ->
+                                case single.problem of
+                                    Parser.Problem message ->
+                                        Expect.fail <| "Failed to parse: " ++ message
 
-                        else if expected then
-                            Expect.fail "Should have matched"
+                                    _ ->
+                                        Expect.fail <| "Failed to parse:[] " ++ Debug.toString e
 
-                        else
-                            Expect.fail "Should not have matched"
+                            Err e ->
+                                Expect.fail <| "Failed to parse: " ++ Debug.toString e
+
+                            Ok validGlob ->
+                                Glob.match validGlob input
+                                    |> Expect.equal expected
+                                    |> Expect.onFail "Should not have matched"
                     )
             )
 

--- a/tests/Utils.elm
+++ b/tests/Utils.elm
@@ -3,7 +3,6 @@ module Utils exposing (Expectation, checkAll, parseAll)
 import Expect
 import Glob
 import Json.Encode
-import List.Extra
 import Parser
 import Set
 import Test exposing (Test, test)
@@ -46,7 +45,6 @@ parseAll expectations =
 checkAll : List Expectation -> List Test
 checkAll expectations =
     expectations
-        |> List.Extra.unique
         |> List.map
             (\{ glob, input, expected } ->
                 test ("Glob: " ++ escape glob ++ " Input: " ++ escape input)

--- a/tests/WcMatch.elm
+++ b/tests/WcMatch.elm
@@ -10,7 +10,6 @@ expectations =
     [ { glob = "src/foo.css", input = "src/foo.css", expected = True }
 
     -- Basic test of traditional features
-    , { glob = "abc", input = "abc", expected = True }
     , { glob = "?*?", input = "abc", expected = True }
     , { glob = "???*", input = "abc", expected = True }
     , { glob = "*???", input = "abc", expected = True }
@@ -46,7 +45,7 @@ expectations =
     -- Wildcard tests
     , { glob = "te*", input = "test", expected = True }
     , { glob = "te*ÿ", input = "testÿ", expected = True }
-    , { glob = "foo*", input = "foo\nbar", expected = True }
+    , { glob = "foo*", input = "foo\nbar\nbaz", expected = True }
 
     -- Ensure that we don't fail on regular expression related symbols
     -- such as &&, ||, ~~, --, or [.  Currently re doesn't do anything with

--- a/tests/WcMatch.elm
+++ b/tests/WcMatch.elm
@@ -52,6 +52,10 @@ expectations =
     -- such as &&, ||, ~~, --, or [.  Currently re doesn't do anything with
     -- && etc., but they are handled special in re as there are plans to utilize them.
     , { glob = "[[]", input = "[", expected = True }
+    , { glob = "[", input = "[", expected = True }
+    , { glob = "[abc", input = "[abc", expected = True }
+    , { glob = "[abc", input = "[ab", expected = False }
+    , { glob = "[abc", input = "[abcd", expected = False }
     , { glob = "[a&&b]", input = "&", expected = True }
     , { glob = "[a||b]", input = "|", expected = True }
     , { glob = "[a~~b]", input = "~", expected = True }

--- a/tests/WcMatch.elm
+++ b/tests/WcMatch.elm
@@ -45,6 +45,7 @@ expectations =
     -- Wildcard tests
     , { glob = "te*", input = "test", expected = True }
     , { glob = "te*ÿ", input = "testÿ", expected = True }
+    , { glob = "te*", input = "testÿ", expected = True }
     , { glob = "foo*", input = "foo\nbar\nbaz", expected = True }
 
     -- Ensure that we don't fail on regular expression related symbols

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -1,6 +1,5 @@
 {
   "tests": [
-    "Glob",
     "./README.md"
   ]
 }


### PR DESCRIPTION
This is a lot of unrelated changes, I felt like it would be faster for me to do one big PR rather than try to get them all done separately. Happy to edit the branch and/or to make additional PRs if you prefer.

Highlights:
- Changing the API to be `elm/regex`-like
- Adding documentation (still need to add examples)
- Some performance improvements and code simplifications
- Support stray `[` in the glob expression

Changes are likely best reviewed commit by commit.

What remains for publication IMO (which I'd be happy to work on afterwards):
- Add code examples in the `Glob` module (probably not much to add though)
- More clearly indiciate this is globbing for **file paths**
- [Optional] Run elm-review and elm-format in the tests, and set up automatic publishing mechanism